### PR TITLE
Install header files globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ PYTHON			?= python
 CLIPS_VERSION		?= 6.31
 CLIPS_SOURCE_URL	?= "https://downloads.sourceforge.net/project/clipsrules/CLIPS/6.31/clips_core_source_631.zip"
 MAKEFILE_NAME		?= makefile
-SHARED_LIBRARY_DIR	?= /usr/lib
+SHARED_INCLUDE_DIR	?= /usr/local/include
+SHARED_LIBRARY_DIR	?= /usr/local/lib
 
 .PHONY: clips clipspy test install clean
 
@@ -27,7 +28,12 @@ test: clipspy
 		$(PYTHON) -m pytest -v
 
 install-clips: clips
-	cp clips_source/libclips.so		 			       \
+	install -d $(SHARED_INCLUDE_DIR)/
+	install -m 644 clips_source/clips.h $(SHARED_INCLUDE_DIR)/
+	install -d $(SHARED_INCLUDE_DIR)/clips
+	install -m 644 clips_source/*.h $(SHARED_INCLUDE_DIR)/clips/
+	install -d $(SHARED_LIBRARY_DIR)/
+	install -m 644 clips_source/libclips.so                                \
 	 	$(SHARED_LIBRARY_DIR)/libclips.so.$(CLIPS_VERSION)
 	ln -s $(SHARED_LIBRARY_DIR)/libclips.so.$(CLIPS_VERSION)	       \
 	 	$(SHARED_LIBRARY_DIR)/libclips.so.6


### PR DESCRIPTION
Do this so clipspy can be built from source (e.g. `make install`) and then used in installations by virtual environments (e.g. `pipenv install clipspy`).

This matters for systems for which there is no Wheel provided.

Important note: also changes the installation directory from `/usr/` to `/usr/local`, which seems proper for programs that are essentially built from source and not by the system's package manager.