### PR TITLE
Problem: can't use unhashable Python objects

### DIFF
--- a/clips/values.py
+++ b/clips/values.py
@@ -102,7 +102,7 @@ def clips_external_address(env: ffi.CData, value: type) -> ffi.CData:
 
     # Hold reference to CData handle
     user_functions = common.environment_data(env, 'user_functions')
-    user_functions.external_addresses[value] = handle
+    user_functions.external_addresses[handle] = (handle, value)
 
     return lib.CreateCExternalAddress(env, handle)
 
@@ -113,7 +113,7 @@ def python_external_address(env: ffi.CData, value: ffi.CData) -> type:
 
     # Remove reference to CData handle
     user_functions = common.environment_data(env, 'user_functions')
-    del user_functions.external_addresses[obj]
+    del user_functions.external_addresses[value.externalAddressValue.contents]
 
     return obj
 

--- a/test/environment_test.py
+++ b/test/environment_test.py
@@ -136,6 +136,16 @@ class TestEnvironment(unittest.TestCase):
 
         self.assertEqual(ret, test_object)
 
+    def test_call_python_unhashable(self):
+        """Unhashable objects are correctly marshalled."""
+        from collections.abc import Hashable
+        test_dict = {'test': 'passed'}
+        self.assertNotIsInstance(test_dict, Hashable)
+
+        ret = self.env.call('python_objects', test_dict)
+
+        self.assertEqual(ret, test_dict)
+
     def test_rule_python_fact(self):
         """Facts are forwarded to Python """
         fact = self.env.assert_string('(test-fact)')


### PR DESCRIPTION
If I will try to pass, say, a `dict`, I will get an error:

```
        user_functions = common.environment_data(env, 'user_functions')
>       user_functions.external_addresses[value] = handle
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: unhashable type: 'dict'
```

Solution: move the value we're holding out of they key and use pointer's value as a key instead.